### PR TITLE
#167276162 Create inputForm Field molecule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1195,9 +1195,15 @@
       "dev": true
     },
     "@testing-library/dom": {
+<<<<<<< HEAD
       "version": "5.5.6",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.5.6.tgz",
       "integrity": "sha512-gcvncl8vyuC9ZSjDZGdcq86W5SrTtia8ID4ErEuqZQ0StG1bQlfXhl1726qf2C0ALFI9OZfRazbeeIEgJlzyGA==",
+=======
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.0.tgz",
+      "integrity": "sha512-nAsRvQLr/b6TGNjuHMEbWXCNPLrQYnzqa/KKQZL7wBOtfptUxsa4Ah9aqkHW0ZmCSFmUDj4nFUxWPVTeMu0iCw==",
+>>>>>>> feat(Inputfield): create inputfield molecule
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.5",
@@ -1222,6 +1228,7 @@
         "lodash": "^4.17.11",
         "pretty-format": "^24.0.0",
         "redent": "^3.0.0"
+<<<<<<< HEAD
       }
     },
     "@testing-library/react": {
@@ -1245,6 +1252,20 @@
         }
       }
     },
+=======
+      }
+    },
+    "@testing-library/react": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.5.tgz",
+      "integrity": "sha512-2EzVi7HjUUF8gKzB4s+oCJ1+F4VOrphO+DlUO6Ptgtcz1ko4J2zqnr0t7g+T7uedXXjJ0wdq70zQMhJXP3w37A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.4",
+        "@testing-library/dom": "^5.5.4"
+      }
+    },
+>>>>>>> feat(Inputfield): create inputfield molecule
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
       "^<core>/(.*)$": "<rootDir>/src/core/$1",
       "^<fixtures>/(.*)$": "<rootDir>/src/fixtures/$1",
       "^<atoms>/(.*)$": "<rootDir>/src/components/UI/atoms/$1",
-      "^<molecules>/(.*)$": "<rootDir>/src/components/UI/molecules/$1"
+      "^<molecules>/(.*)$": "<rootDir>/src/components/UI/molecules/$1",
+      "^<helpers>/(.*)$": "<rootDir>/src/helpers/$1"
     },
     "coverageReporters": [
       "json-summary",

--- a/src/components/UI/atoms/Icon/Icon.jsx
+++ b/src/components/UI/atoms/Icon/Icon.jsx
@@ -63,7 +63,7 @@ Icon.defaultProps = {
   color: 'primary',
 };
 
-Icon.Container = styled.svg`
+Icon.Container = styled.div`
 ${({
     color,
     height,

--- a/src/components/UI/atoms/InputField/InputField.jsx
+++ b/src/components/UI/atoms/InputField/InputField.jsx
@@ -12,6 +12,7 @@ import width from '<variables>/width';
  * @description - Input field Component
  *
  * @prop {string} fontSize - font Size
+ * @prop {string} id - for label
  * @prop {string} color - color
  * @prop {string} type - type
  * @prop {string} placeholder - placeholder
@@ -25,6 +26,7 @@ import width from '<variables>/width';
  */
 const InputField = ({
   type,
+  id,
   placeholder,
   name,
   value,
@@ -40,6 +42,7 @@ const InputField = ({
 }) => (
   <InputField.Container
     type={type}
+    id={id}
     placeholder={placeholder}
     name={name}
     value={value}
@@ -57,6 +60,7 @@ const InputField = ({
 
 InputField.propTypes = {
   type: PropTypes.oneOf(['number', 'email', 'password', 'text']).isRequired,
+  id: PropTypes.string,
   placeholder: PropTypes.string,
   name: PropTypes.string,
   value: PropTypes.string,
@@ -72,11 +76,11 @@ InputField.propTypes = {
 };
 
 InputField.defaultProps = {
-  padding: 'zero',
+  padding: 'xs',
   fontSize: 'normal',
   color: 'primary',
   content: 'false',
-  background: 'lightPink',
+  backgroundColor: 'lightPink',
 };
 
 InputField.Container = styled.input`

--- a/src/components/UI/atoms/layouts/FlexContainer/FlexContainer.jsx
+++ b/src/components/UI/atoms/layouts/FlexContainer/FlexContainer.jsx
@@ -55,6 +55,7 @@ FlexContainer.Container = styled.div`
     },
   }) => `
     display: ${display};
+    flex-direction:column;
     background-color: ${backgroundColors[backgroundColor]};
     margin: ${spacing[margin]};
     padding: ${spacing[padding]};

--- a/src/components/UI/molecules/InputTextField/InputTextField.jsx
+++ b/src/components/UI/molecules/InputTextField/InputTextField.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import InputField from '<atoms>/InputField/InputField';
+import Text from '<atoms>/Text/Text';
+import FlexContainer from '<atoms>/layouts/FlexContainer/FlexContainer';
+import Label from '<molecules>/label/Label';
+import themeBorderRadius from '<variables>/border';
+import width from '<variables>/width';
+import { textColors } from '<variables>/colorPalette';
+
+/**
+ * @description - InputFormField component combined with an error field
+ *
+ * @prop {string} - placeholder
+ * @prop {string | number} - value
+ * @prop {string} - errorMessage
+ * @prop {func} - onChange
+ * @prop {string} - inputWidth
+ *
+ * @returns {JSX} - Input, Text, FlexContainer Component
+ *
+ * InputForm field Component
+ */
+const InputTextField = ({
+  value,
+  placeholder,
+  onChange,
+  errorMessage,
+  inputWidth,
+  borderRadius,
+  type,
+  name,
+  label,
+  color,
+}) => {
+  const id = btoa(`${name}-${value}`);
+
+  return (
+
+    <FlexContainer>
+      {label && <Label
+        id={id}
+        htmlFor={id}
+        color = {color}
+      >
+        {label}
+      </Label>}
+      <InputField
+        id={id}
+        name={name}
+        type={type}
+        placeholder={placeholder}
+        value={value}
+        inputWidth={inputWidth}
+        borderRadius={borderRadius}
+        error={errorMessage}
+        onChange={onChange} />
+      {errorMessage
+        && <span><Text color='red' fontSize='small' display='block'>
+          {errorMessage}
+        </Text></span>}
+    </FlexContainer>
+
+  );
+};
+
+InputTextField.propTypes = {
+  type: PropTypes.oneOf(['number', 'email', 'password', 'text']).isRequired,
+  label: PropTypes.string,
+  inputWidth: PropTypes.oneOf(Object.keys(width)),
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string,
+  borderRadius: PropTypes.oneOf(Object.keys(themeBorderRadius)),
+  onChange: PropTypes.func.isRequired,
+  color: PropTypes.oneOf(Object.keys(textColors)),
+};
+
+InputTextField.defaultProps = {
+  type: 'text',
+};
+
+export default InputTextField;

--- a/src/components/UI/molecules/InputTextField/InputTextField.md
+++ b/src/components/UI/molecules/InputTextField/InputTextField.md
@@ -1,0 +1,65 @@
+InputFormField Default:
+```jsx
+<InputTextField
+  label='First Name'
+  name='firstname'
+  type='text'
+  placeholder='Enter first name'
+  onChange={e => setText(e.target.value)}
+  inputWidth='fullWidth'
+  value='asd1'
+/>
+```
+
+example
+```jsx
+<InputTextField
+  label='First Name'
+  name='firstname'
+  type='text'
+  placeholder='enter first name'
+  onChange={e => setText(e.target.value)}
+  inputWidth='fullWidth'
+  value='asd2'
+/>
+```
+Form field with password 
+```jsx
+<InputTextField
+  label='Password '
+  name='password'
+  type='password'
+  placeholder='enter password'
+  onChange={e => setText(e.target.value)}
+  inputWidth='fullWidth'
+  value='asd3'
+/>
+```
+
+Form field with error message
+```jsx
+<InputTextField
+  label='First Name'
+  name='firstname'
+  type='password'
+  placeholder='enter first name'
+  onChange={e => setText(e.target.value)}
+  inputWidth='fullWidth'
+  errorMessage='first name is required'
+  value='asd4'
+/>
+```
+
+Form field with half width
+```jsx
+<InputTextField
+  label='First Name'
+  name='firstname'
+  type='text'
+  placeholder='enter first name'
+  onChange={e => setText(e.target.value)}
+  inputWidth='searchBarWidth'
+  errorMessage='first name is required'
+  value='asd5'
+/>
+```

--- a/src/components/UI/molecules/InputTextField/InputTextField.spec.js
+++ b/src/components/UI/molecules/InputTextField/InputTextField.spec.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, cleanup } from '<src>/helpers/testUtils';
+import InputTextField from './InputTextField';
+import '@testing-library/jest-dom/extend-expect';
+
+afterEach(cleanup);
+
+const defaultProps = {
+  label: 'First Name',
+  name: 'firstname',
+  type: 'text',
+  errorMessage: 'this field required',
+  onChange: () => {},
+};
+
+const setUp = (props) => {
+  const utils = render(<InputTextField {...defaultProps} {...props} />);
+  return utils;
+};
+
+describe('Input Text Fields', () => {
+  it('should render a input field component', () => {
+    const { container } = setUp();
+    expect(container).toBeTruthy();
+  });
+
+  it('should render  and return the first name', () => {
+    const { getByLabelText } = setUp({ type: 'password' });
+    const input = getByLabelText(defaultProps.label);
+
+    expect(input.getAttribute('name')).toBe('firstname');
+  });
+
+
+  it('should render a input password field component', () => {
+    const { getByLabelText } = setUp({ type: 'password' });
+    const input = getByLabelText(defaultProps.label);
+
+    expect(input.getAttribute('type')).toBe('password');
+  });
+
+  it('should render a input password field component and return the id', () => {
+    const { getByLabelText } = setUp({ type: 'password' });
+    const input = getByLabelText(defaultProps.label);
+    const value = input.getAttribute('id');
+
+    expect(input.getAttribute(input.attributes[1].name)).toBe(value);
+  });
+
+  it('should render password field component and return error message', () => {
+    const { container } = setUp({ type: 'password' });
+
+    expect(container.lastChild).toHaveTextContent(defaultProps.errorMessage);
+  });
+});

--- a/src/components/UI/molecules/label/Label.jsx
+++ b/src/components/UI/molecules/label/Label.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { fontWeights, fontSizes } from '<variables>/fonts';
+import { textColors } from '<variables>/colorPalette';
+import Text from '<atoms>/Text/Text';
+
+
+/**
+ * @description - InputFormField component combined with an error field
+ *
+ * @prop {children} - children
+ *
+ * @returns {JSX} - label
+ *
+ * InputLabel field Component
+ */
+const Label = ({
+  children,
+  display,
+  color,
+  id,
+  fontSize,
+  fontWeight,
+}) => (
+  <Label.Container htmlFor={id} display={display}>
+    <Text
+      content='true'
+      color={color}
+      fontSize={fontSize}
+      fontWeight={fontWeight}
+    >
+      {children}
+    </Text>
+  </Label.Container>
+);
+
+Label.Container = styled.label`
+${({
+    fontSize,
+    fontWeight,
+    display,
+    color,
+    theme,
+  }) => {
+    return `
+  color: ${theme.textColors[color]};
+  display: ${display};
+  font-size: ${theme.fontSizes[fontSize]};
+  font-weight: ${theme.fontWeights[fontWeight]};
+`;
+  }}
+`;
+
+
+Label.propTypes = {
+  id: PropTypes.string.isRequired,
+  display: PropTypes.oneOf(['block', 'inline', 'flex', 'inline-block', 'none']),
+  color: PropTypes.oneOf(Object.keys(textColors)),
+  fontSize: PropTypes.oneOf(Object.keys(fontSizes)),
+  fontWeight: PropTypes.oneOf(Object.keys(fontWeights)),
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
+};
+
+Label.defaultProps = {
+  children: 'text',
+  color: 'primary',
+  display: 'block',
+  fontWeight: 'normal',
+  fontSize: 'normal',
+};
+
+export default Label;

--- a/src/components/UI/molecules/label/Label.md
+++ b/src/components/UI/molecules/label/Label.md
@@ -1,0 +1,14 @@
+InputLabel Default:
+```jsx
+<Label id ='firstname'> First Name </Label>
+```
+
+InputLabel with different color:
+```jsx
+<Label id ='firstname' color='red'> First Name </Label>
+```
+
+InputLabel with different color:
+```jsx
+<Label id ='firstname' fontSize='small'> First Name </Label>
+```

--- a/src/components/UI/molecules/label/Label.spec.js
+++ b/src/components/UI/molecules/label/Label.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, cleanup } from '<src>/helpers/testUtils';
+import Label from './Label';
+import '@testing-library/jest-dom/extend-expect';
+
+afterEach(cleanup);
+
+const defaultProps = {
+  content: 'true',
+  children: 'First Name',
+};
+
+const id = btoa(defaultProps.children);
+
+const setUp = (props) => {
+  const utils = render(
+    <Label
+      id={id}
+      {...defaultProps}
+      {...props}
+    >
+      {defaultProps.children}
+    </Label>,
+  );
+  return utils;
+};
+
+describe('Label', () => {
+  it('should render a input field component', () => {
+    const { container } = setUp();
+
+    expect(container).toBeTruthy();
+  });
+
+
+  it('should return color red', () => {
+    const { getByText } = setUp({ color: 'red' });
+    const label = getByText('First Name');
+
+    expect(label.getAttribute('color')).toBe('red');
+  });
+
+  it('should return for ', () => {
+    const { getByText } = setUp({ color: 'red' });
+    const label = getByText('First Name');
+
+    expect(label.parentElement.getAttribute('for')).toBe(id);
+  });
+});

--- a/src/styles/variables/colorPalette.js
+++ b/src/styles/variables/colorPalette.js
@@ -8,6 +8,7 @@ export const buttonColors = {
 export const textColors = {
   primary: '#B02091',
   grey: '#7A757E',
+  red: '#FF0000',
 };
 
 export const backgroundColors = {

--- a/src/styles/variables/fonts.js
+++ b/src/styles/variables/fonts.js
@@ -1,5 +1,6 @@
 export const fontSizes = {
-  small: '0.8rem',
+  smaller: '0.8rem',
+  small: '1.0rem',
   normal: '1.6rem',
   title: '2.0rem',
   medium: '2.4rem',

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -56,8 +56,10 @@ module.exports = {
       '<components>': path.resolve(__dirname, '../src/components'),
       '<core>': path.resolve(__dirname, '../src/core'),
       '<atoms>': path.resolve(__dirname, '../src/components/UI/atoms'),
+      '<molecules>':path.resolve(__dirname,'../src/components/UI/molecules'),
       '<image>':path.resolve(__dirname,'../public/assets/images'),
       '<molecules>': path.resolve(__dirname, '../src/components/UI/molecules'),
+      '<helpers>':path.resolve(__dirname,'../src/helpers')
     },
     extensions: [' ', '.js', '.jsx'],
   },


### PR DESCRIPTION
#### What does this PR do?

- This PR sets up an Input Form field molecule with styleguide

#### Description of task to be completed?

- setup input form field molecule
- setup styleguidist for the input form field molecule
- write tests for the input form field molecule
- refactor divider to display inline
- add web pack molecule module resolver
- add jest config molecule module resolver
- add molecule sections to style guide configuration

#### How should this be manually tested?

  - $ git clone https://github.com/andela/king-kong-ah-frontend.git
  - $ npm install
  - $ npm test

#### Any background context you want to provide?

- You would need npm to run this application

#### What are the relevant pivotal tracker stories?

- PT Story link - [#167276162](https://www.pivotaltracker.com/story/show/167276162)

#### Screenshots (if appropriate)
<img width="1432" alt="Screenshot 2019-07-13 at 7 25 18 PM" src="https://user-images.githubusercontent.com/19696366/61175259-fe86a500-a5a3-11e9-9c60-ec8edf155737.png">

